### PR TITLE
增加 强制显示顶栏模糊选项 功能

### DIFF
--- a/app/src/main/java/cc/ioctl/tmoe/base/DynamicHookInit.java
+++ b/app/src/main/java/cc/ioctl/tmoe/base/DynamicHookInit.java
@@ -13,6 +13,7 @@ import cc.ioctl.tmoe.hook.func.AntiAntiCopy;
 import cc.ioctl.tmoe.hook.func.AntiAntiForward;
 import cc.ioctl.tmoe.hook.func.ChannelDetailNumbers;
 import cc.ioctl.tmoe.hook.func.EnableDebugMode;
+import cc.ioctl.tmoe.hook.func.ForceBlurChatAvailable;
 import cc.ioctl.tmoe.hook.func.HidePhoneNumber;
 import cc.ioctl.tmoe.hook.func.HideUserAvatar;
 import cc.ioctl.tmoe.hook.func.HistoricalNewsOption;
@@ -71,6 +72,7 @@ public class DynamicHookInit {
                     SendCommand.INSTANCE,
                     ShowMsgId.INSTANCE,
                     AddReloadMsgBtn.INSTANCE,
+                    ForceBlurChatAvailable.INSTANCE,
             };
         }
         return sAllFunctionHooks;

--- a/app/src/main/java/cc/ioctl/tmoe/fragment/SettingsFragment.kt
+++ b/app/src/main/java/cc/ioctl/tmoe/fragment/SettingsFragment.kt
@@ -93,6 +93,9 @@ class SettingsFragment : BaseHierarchyFragment() {
             functionSwitch(
                 SendCommand, "SendCommand",  R.string.SendCommand
             )
+            functionSwitch(
+                ForceBlurChatAvailable, "ForceBlurChatAvailable",  R.string.ForceBlurChatAvailable
+            )
 
         }
         category("LostMsgMitigation", R.string.LostMsgMitigation) {

--- a/app/src/main/java/cc/ioctl/tmoe/hook/func/ForceBlurChatAvailable.kt
+++ b/app/src/main/java/cc/ioctl/tmoe/hook/func/ForceBlurChatAvailable.kt
@@ -1,0 +1,17 @@
+package cc.ioctl.tmoe.hook.func
+
+import cc.ioctl.tmoe.hook.base.CommonDynamicHook
+import com.github.kyuubiran.ezxhelper.utils.*
+
+object ForceBlurChatAvailable : CommonDynamicHook() {
+    override fun initOnce(): Boolean = tryOrFalse {
+        // 强制显示顶栏模糊选项
+        findMethod(loadClass("org.telegram.messenger.SharedConfig")){
+            name=="canBlurChat"
+        }.hookBefore {
+            if (!isEnabled)return@hookBefore
+
+            it.result = true
+        }
+    }
+}

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -42,4 +42,5 @@
     <string name="LostMsgMitigation">Si se han perdido mensajes</string>
     <string name="AddReloadMsgBtn">Botón de recarga de mensajes</string>
     <string name="AddReloadMsgBtnDesc">Añadir el botón de recarga de mensajes en el menú del chat</string>
+    <string name="ForceBlurChatAvailable">Forzar la opción de desenfoque de la barra superior</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -41,4 +41,5 @@
     <string name="AddReloadMsgBtn">添加刷新消息按钮</string>
     <string name="AddReloadMsgBtnDesc">在聊天菜单添加刷新消息按钮</string>
     <string name="RestrictContentMitigationDesc">允许在私密聊天界面复制消息保存文件以及截图</string>
+    <string name="ForceBlurChatAvailable">强制显示顶栏模糊选项</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -40,4 +40,5 @@
     <string name="LostMsgMitigation">針對訊息遺失的輔助手段</string>
     <string name="AddReloadMsgBtn">新增重新整理訊息按鈕</string>
     <string name="AddReloadMsgBtnDesc">在聊天選單新增重新整理訊息按鈕</string>
+    <string name="ForceBlurChatAvailable">強制顯示頂欄模糊選項</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="AddInfoContainerD">AddInfoContainer</string>
     <string name="ProhibitSpoilers">Prohibit Spoilers</string>
     <string name="SendCommand">Ask for tap command</string>
+    <string name="ForceBlurChatAvailable">Force Chat Blur Option Available</string>
     <string name="AntiAntiCopy">Anti-Anti-Copy message</string>
     <string name="AntiAntiCopyD">Conflict with Anti-Anti-Forward</string>
     <string name="ChatUiSettings">Chat Settings</string>


### PR DESCRIPTION
Telegram 根据硬件信息将手机性能划为三档（LOW、AVERAGE、HIGH），并仅对 HIGH 的手机提供顶栏模糊（Chat Settings - Blur in Chat）功能。

此选项可以强制这个功能对所有手机可用。